### PR TITLE
fix: use attemptNumber instead of attemptId

### DIFF
--- a/src/main/java/io/opentelemetry/javaagent/instrumentation/spark/v2_4/SparkEventListener.java
+++ b/src/main/java/io/opentelemetry/javaagent/instrumentation/spark/v2_4/SparkEventListener.java
@@ -115,14 +115,14 @@ public class SparkEventListener {
     ActiveJob firstJob = ApacheSparkSingletons.findJob(jobId);
     Context firstJobContext = ApacheSparkSingletons.getJobContext(firstJob);
 
-    Integer attemptId = stageInfo.attemptId();
+    Integer attemptId = stageInfo.attemptNumber();
 
     SpanBuilder builder =
         ApacheSparkSingletons.TRACER
             .spanBuilder(String.format("Stage %s", stage.id()))
             .setParent(firstJobContext)
             .setAttribute("stage_id", stageId)
-            .setAttribute("stage_atteampt_id", attemptId)
+            .setAttribute("stage_attempt_id", attemptId)
             .setStartTimestamp((Long) stageInfo.submissionTime().get(), TimeUnit.MILLISECONDS);
 
     for (Object id : JavaConversions.asJavaCollection(stage.jobIds())) {


### PR DESCRIPTION
`attemptId` is deprecated in favour of `attemptNumber` since spark 2.3.0. 

This change also fixes the library's instrumentation of spark 3 jobs, as previously the library was not loading due to failed muzzle checks caused by `attemptId`.

I think we can keep the same label name as `stage_attempt_id` as it is still a commonly referenced term across spark's documentation. 