### PR TITLE
Fix context propagation for job spans

### DIFF
--- a/src/main/java/io/opentelemetry/javaagent/instrumentation/spark/SparkEventListener.java
+++ b/src/main/java/io/opentelemetry/javaagent/instrumentation/spark/SparkEventListener.java
@@ -52,7 +52,11 @@ public class SparkEventListener {
   public static void onJobStart(SparkListenerJobStart event) {
 
     Integer jobId = event.jobId();
-    Context parentContext = Context.current();
+
+    Context parentContext = ApacheSparkSingletons.getJobContext(jobId);
+    if (parentContext == null) {
+      parentContext = Context.current();
+    }
 
     Span jobSpan =
         ApacheSparkSingletons.TRACER


### PR DESCRIPTION
Fixes #9.

* I tried to get a context in the `onJobStart` function and got an invalid (empty) Context.
* Following the author's idea, I found where to get the context from an application.
   It can be obtained in the `DAGScheduler` class when submitting a job.
* We can also get it in functions `$anonfun$submitJob$1`, `eventProcessLoop`, `runJob`, `sc` and `submitJob`, but I think it's better to get it at submission time.

### Notes

* I used the `ContextStorage` class to get `null` instead of empty `Context` ([reference](https://github.com/open-telemetry/opentelemetry-java/blob/94238acd7167acc6d211ae70c87caa7751b0fb29/context/src/main/java/io/opentelemetry/context/Context.java#L91)).
* I leave `Context.current()` in the `SparkEventListener` class just in case it originally worked (or works in some author's case).
* Probably need to add `takesArgument` to the element matchers.